### PR TITLE
chore: replace import

### DIFF
--- a/app/components/Contact/ContactForm.tsx
+++ b/app/components/Contact/ContactForm.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from 'react'
-import { useFetcher } from 'remix'
-import { ActionType } from '~/routes'
-import type { ActionData as IndexActionData } from '~/routes'
-import type { Language, Translations } from '~/utils/i18n.server'
-import { useHydrated } from '~/hooks/useHydrated'
+import { useFetcher } from '@remix-run/react'
 import clsx from 'clsx'
+import { useEffect, useRef } from 'react'
+import { useHydrated } from '~/hooks/useHydrated'
+import type { ActionData as IndexActionData } from '~/routes'
+import { ActionType } from '~/routes'
+import type { Language, Translations } from '~/utils/i18n.server'
 
 interface Props {
   translation: Translations['contact'][Language]

--- a/app/components/DropdownMenu.tsx
+++ b/app/components/DropdownMenu.tsx
@@ -1,16 +1,16 @@
 import {
+  Arrow,
+  Content,
+  Item,
   Root,
   Trigger,
-  Content,
   TriggerItem,
-  Item,
-  Arrow,
 } from '@radix-ui/react-dropdown-menu'
-import { useMatches, useSubmit } from 'remix'
+import { useMatches, useSubmit } from '@remix-run/react'
+import Icon from '~/components/Icon'
 import { useTheme } from '~/hooks/useTheme'
 import { ActionType } from '~/routes'
 import type { Language, Translations } from '~/utils/i18n.server'
-import Icon from './Icon'
 
 interface Props {
   translation: Translations['heroHeader'][Language]

--- a/app/components/ErrorPage.tsx
+++ b/app/components/ErrorPage.tsx
@@ -1,7 +1,7 @@
-import { Link } from 'remix'
-import type { Language, Translations } from '~/utils/i18n.server'
+import { Link } from '@remix-run/react'
 import Error500ImageUrl from '~/assets/images/undraw_lost.svg'
 import Error404ImageUrl from '~/assets/images/undraw_page_not_found.svg'
+import type { Language, Translations } from '~/utils/i18n.server'
 
 interface Props {
   page: 404 | 500

--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
-import Icon from '../Icon'
-import type { IconIdType } from '../Icon'
+import type { IconIdType } from '~/components/Icon'
+import Icon from '~/components/Icon'
 
 const socials: { name: string; href: string; iconId: IconIdType }[] = [
   {

--- a/app/components/Hero/GetFactCode.tsx
+++ b/app/components/Hero/GetFactCode.tsx
@@ -1,5 +1,5 @@
+import { useFetcher } from '@remix-run/react'
 import { useEffect, useState } from 'react'
-import { useFetcher } from 'remix'
 import Icon from '~/components/Icon'
 import type { Language, Translations } from '~/utils/i18n.server'
 

--- a/app/components/Hero/Hero.tsx
+++ b/app/components/Hero/Hero.tsx
@@ -1,4 +1,4 @@
-import type { Translations, Language } from '~/utils/i18n.server'
+import type { Language, Translations } from '~/utils/i18n.server'
 import GetFactCode from './GetFactCode'
 import HeroHeader from './HeroHeader/HeroHeader'
 import Introduction from './Introduction'

--- a/app/components/Hero/HeroHeader/HeroHeader.tsx
+++ b/app/components/Hero/HeroHeader/HeroHeader.tsx
@@ -1,9 +1,9 @@
 import { Popover } from '@headlessui/react'
+import { Link } from '@remix-run/react'
 import Icon from '~/components/Icon'
-import HeroHeaderNav from './HeroHeaderNav'
-import { Link } from 'remix'
-import HeroHeaderNavMobile from './HeroHeaderNavMobile'
 import type { Language, Translations } from '~/utils/i18n.server'
+import HeroHeaderNav from './HeroHeaderNav'
+import HeroHeaderNavMobile from './HeroHeaderNavMobile'
 
 interface Props {
   translation: Translations['heroHeader'][Language]

--- a/app/components/Hero/HeroHeader/HeroHeaderNav.tsx
+++ b/app/components/Hero/HeroHeader/HeroHeaderNav.tsx
@@ -1,7 +1,7 @@
-import { Link } from 'remix'
+import { Link } from '@remix-run/react'
+import DropdownMenu from '~/components/DropdownMenu'
 import Icon from '~/components/Icon'
 import type { Language, Translations } from '~/utils/i18n.server'
-import DropdownMenu from '~/components/DropdownMenu'
 
 interface Props {
   translation: Translations['heroHeader'][Language]

--- a/app/components/Hero/HeroHeader/HeroHeaderNavMobile.tsx
+++ b/app/components/Hero/HeroHeader/HeroHeaderNavMobile.tsx
@@ -1,6 +1,6 @@
 import { Popover, Transition } from '@headlessui/react'
+import { Link } from '@remix-run/react'
 import { Fragment } from 'react'
-import { Link } from 'remix'
 import Icon from '~/components/Icon'
 import LanguageSwitcher from '~/components/LanguageSwitcher'
 import type { Language, Translations } from '~/utils/i18n.server'

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
-import type { Language, Translations } from '~/utils/i18n.server'
-import { useSubmit } from 'remix'
+import { useSubmit } from '@remix-run/react'
 import { ActionType } from '~/routes'
+import type { Language, Translations } from '~/utils/i18n.server'
 
 interface Props {
   translation: Translations['heroHeader'][Language]

--- a/app/components/Section.tsx
+++ b/app/components/Section.tsx
@@ -1,12 +1,11 @@
 import clsx from 'clsx'
-import { ReactNode } from 'react'
 
 interface Props {
   id: string
   title: string
   description?: string
   scaleUpColor?: boolean
-  children: ReactNode
+  children: React.ReactNode
 }
 
 export default function Section({

--- a/app/components/Tool/Tool.tsx
+++ b/app/components/Tool/Tool.tsx
@@ -1,6 +1,6 @@
 import Section from '~/components/Section'
 import type { Language, Translations } from '~/utils/i18n.server'
-import ToolTabs, { TabTriggerType, TabContentType } from './ToolTabs'
+import ToolTabs, { TabContentType, TabTriggerType } from './ToolTabs'
 
 interface Props {
   translation: Translations['tool'][Language]

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,4 +1,4 @@
+import { RemixBrowser } from '@remix-run/react'
 import { hydrate } from 'react-dom'
-import { RemixBrowser } from 'remix'
 
 hydrate(<RemixBrowser />, document)

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,6 @@
+import type { EntryContext } from '@remix-run/cloudflare'
+import { RemixServer } from '@remix-run/react'
 import { renderToString } from 'react-dom/server'
-import { RemixServer } from 'remix'
-import type { EntryContext } from 'remix'
 
 export default function handleRequest(
   request: Request,

--- a/app/hooks/useTheme.tsx
+++ b/app/hooks/useTheme.tsx
@@ -1,4 +1,4 @@
-import { useTransition } from 'remix'
+import { useTransition } from '@remix-run/react'
 
 function checkTheme(theme?: string) {
   if (theme === 'dark' || theme === 'light') return theme

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,11 @@
+import * as Toast from '@radix-ui/react-toast'
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/cloudflare'
+import { json } from '@remix-run/cloudflare'
 import {
-  json,
   Links,
   LiveReload,
   Meta,
@@ -8,23 +14,19 @@ import {
   ScrollRestoration,
   useCatch,
   useLoaderData,
-} from 'remix'
-import type { MetaFunction, LinksFunction, LoaderFunction } from 'remix'
-import tailwindStylesUrl from './styles/build/tailwind.css'
+} from '@remix-run/react'
 import clsx from 'clsx'
-import { useTheme } from './hooks/useTheme'
-import { getTheme } from './utils/theme.server'
-
-import * as Toast from '@radix-ui/react-toast'
 import { ReactNode } from 'react'
 import ErrorPage from '~/components/ErrorPage'
-
+import NotificationToast from '~/components/NotificationToast'
+import { useTheme } from './hooks/useTheme'
+import tailwindStylesUrl from './styles/build/tailwind.css'
 import {
   commitNotificationSession,
   getFlashNotification,
   Notification,
 } from './utils/notification.server'
-import NotificationToast from '~/components/NotificationToast'
+import { getTheme } from './utils/theme.server'
 
 export const meta: MetaFunction = () => {
   return { description: 'Get to know Jody Geraldo' }

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,7 +1,7 @@
-import { json } from 'remix'
-import type { LoaderFunction } from 'remix'
-import { getTheme } from '~/utils/theme.server'
+import type { LoaderFunction } from '@remix-run/cloudflare'
+import { json } from '@remix-run/cloudflare'
 import { getLanguage, getTranslations } from '~/utils/i18n.server'
+import { getTheme } from '~/utils/theme.server'
 
 export const loader: LoaderFunction = async ({ request }) => {
   const language = await getLanguage(request)

--- a/app/routes/api/get-fact.tsx
+++ b/app/routes/api/get-fact.tsx
@@ -1,5 +1,5 @@
-import { json } from 'remix'
-import type { LoaderFunction } from 'remix'
+import type { LoaderFunction } from '@remix-run/cloudflare'
+import { json } from '@remix-run/cloudflare'
 import { getRandomFact } from '~/utils/get-fact.server'
 import { getLanguage } from '~/utils/i18n.server'
 

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,28 +1,26 @@
-import { json, redirect, useLoaderData } from 'remix'
-import type {
-  ActionFunction,
-  LoaderFunction,
-  ShouldReloadFunction,
-} from 'remix'
+import type { ActionFunction, LoaderFunction } from '@remix-run/cloudflare'
+import { json, redirect } from '@remix-run/cloudflare'
+import type { ShouldReloadFunction } from '@remix-run/react'
+import { useLoaderData } from '@remix-run/react'
 import invariant from 'tiny-invariant'
 import Contact from '~/components/Contact/Contact'
 import Footer from '~/components/Footer/Footer'
 import Hero from '~/components/Hero/Hero'
 import Project from '~/components/Project/Project'
 import Tool from '~/components/Tool/Tool'
-import { commitThemeSession, setTheme } from '~/utils/theme.server'
-import { sendMail, validateMailRequest } from '~/utils/mail.server'
+import type { Language, Translations } from '~/utils/i18n.server'
 import {
   commitLanguageSession,
   getLanguage,
   getTranslations,
   setLanguage,
 } from '~/utils/i18n.server'
-import type { Language, Translations } from '~/utils/i18n.server'
+import { sendMail, validateMailRequest } from '~/utils/mail.server'
 import {
   commitNotificationSession,
   setFlashNotification,
 } from '~/utils/notification.server'
+import { commitThemeSession, setTheme } from '~/utils/theme.server'
 
 export enum ActionType {
   SET_THEME = 'SET_THEME',

--- a/app/utils/i18n.server.ts
+++ b/app/utils/i18n.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage, Session } from 'remix'
+import { createCookieSessionStorage, Session } from '@remix-run/cloudflare'
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({

--- a/app/utils/notification.server.ts
+++ b/app/utils/notification.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage } from 'remix'
+import { createCookieSessionStorage } from '@remix-run/cloudflare'
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({

--- a/app/utils/theme.server.ts
+++ b/app/utils/theme.server.ts
@@ -1,4 +1,4 @@
-import { createCookieSessionStorage, Session } from 'remix'
+import { createCookieSessionStorage, Session } from '@remix-run/cloudflare'
 
 const { getSession, commitSession, destroySession } =
   createCookieSessionStorage({

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,18 @@
   "packages": {
     "": {
       "name": "jodygeraldo.com",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.5.0",
         "@radix-ui/react-dropdown-menu": "^0.1.6",
         "@radix-ui/react-tabs": "^0.1.5",
         "@radix-ui/react-toast": "^0.1.1",
+        "@remix-run/cloudflare": "^1.3.4",
         "@remix-run/cloudflare-pages": "^1.3.4",
         "@remix-run/react": "^1.3.4",
         "clsx": "^1.1.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "remix": "^1.3.4",
         "tiny-invariant": "^1.2.0"
       },
       "devDependencies": {
@@ -9312,11 +9311,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remix": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-1.3.4.tgz",
-      "integrity": "sha512-rUfoz7qgExOPzcNvoyBPAj9aOIKIcwvjiXA8O9NLCwxuIZ3lIUggFxqLI38HMwIlUUhNhA6keuYbRu9iWJCCQA=="
-    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -17881,11 +17875,6 @@
         "mdast-util-to-hast": "^11.0.0",
         "unified": "^10.0.0"
       }
-    },
-    "remix": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/remix/-/remix-1.3.4.tgz",
-      "integrity": "sha512-rUfoz7qgExOPzcNvoyBPAj9aOIKIcwvjiXA8O9NLCwxuIZ3lIUggFxqLI38HMwIlUUhNhA6keuYbRu9iWJCCQA=="
     },
     "requireindex": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "sideEffects": false,
   "scripts": {
-    "postinstall": "remix setup cloudflare",
     "cleanup": "rimraf ./.cache ./node_modules ./public/build ./functions",
     "generate:css": "tailwindcss -i ./app/styles/tailwind.css -o ./app/styles/build/tailwind.css",
     "build:css": "npm run generate:css -- --minify",
@@ -28,11 +27,11 @@
     "@radix-ui/react-tabs": "^0.1.5",
     "@radix-ui/react-toast": "^0.1.1",
     "@remix-run/cloudflare-pages": "^1.3.4",
+    "@remix-run/cloudflare": "^1.3.4",
     "@remix-run/react": "^1.3.4",
     "clsx": "^1.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "^1.3.4",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
remix deprecting the magic import from remix package
server stuff imported from `@remix-run/cloudflare`
client stuff imported from `@remix-run/react`